### PR TITLE
Fix token requests

### DIFF
--- a/api/settlement/api_test.go
+++ b/api/settlement/api_test.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/failuretoload/datamonster/web"
 	"io"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/failuretoload/datamonster/web"
 
 	storeMocks "github.com/failuretoload/datamonster/store/mocks"
 	webMocks "github.com/failuretoload/datamonster/web/mocks"
@@ -69,9 +70,9 @@ func (suite *SettlementApiTestSuite) Test_GetSettlements_ReturnsSettmentsList() 
 
 	suite.Equal(200, resp.StatusCode, "200 response should be returned")
 	body, _ := io.ReadAll(resp.Body)
-	dto := SettlementsDTO{}
+	dto := []SettlementDTO{}
 	json.Unmarshal(body, &dto)
-	suite.Equal(2, dto.Count, "2 settlements should be returned")
+	suite.Equal(2, len(dto), "2 settlements should be returned")
 }
 
 func (suite *SettlementApiTestSuite) Test_GetSettlements_ReportsScanErrors() {

--- a/web/src/components/authProvider.tsx
+++ b/web/src/components/authProvider.tsx
@@ -29,6 +29,7 @@ const Auth0ProviderWithNavigate = ({
       authorizationParams={{
         audience: audience,
         redirect_uri: redirectUri,
+        scope: "read:settlements create:settlements update:settlements",
       }}
       onRedirectCallback={onRedirectCallback}
     >

--- a/web/src/routes/settlementSelector/index.tsx
+++ b/web/src/routes/settlementSelector/index.tsx
@@ -1,12 +1,4 @@
 import api from "@/api/settlement";
 import Selector from "./selector";
 
-export async function SettlementListLoader() {
-  let settlements = await api.getSettlementsForUser();
-  if (!settlements) {
-    return null;
-  }
-  return settlements;
-}
-
 export default Selector;

--- a/web/src/routes/settlementSelector/selector.tsx
+++ b/web/src/routes/settlementSelector/selector.tsx
@@ -59,7 +59,7 @@ function SettlementList({ settlements }: SettlementListProps) {
 async function getSettlementsForUser(
   client: Auth0ContextInterface<User>,
 ): Promise<Array<Settlement> | null> {
-  const token = await client.getAccessTokenWithPopup({
+  const token = await client.getAccessTokenSilently({
     authorizationParams: {
       audience: import.meta.env.VITE_AUTH0_AUDIENCE,
       scope: "read:settlements",


### PR DESCRIPTION
In the original guide I followed scopes were left out of the initial creation of the auth client. That was the missing piece for setting up silent token requests.